### PR TITLE
Feature/subgroup size 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ $ ./build/bench 10000000 vulkan
 - [ ] Compare with VkRadixSort
 - [ ] Compare with Fuchsia radix sort
 - [ ] Find best `WORKGROUP_SIZE` and `PARTITION_DIVISION` for different devices.
-- [ ] Support for SubgroupSize=64.
+- [x] Support for SubgroupSize=64.
 
 
 ## References

--- a/src/shader/downsweep.comp
+++ b/src/shader/downsweep.comp
@@ -140,7 +140,7 @@ void main() {
   }
   barrier();
   
-  // local histogram reduce 4096
+  // local histogram reduce 4096 or 2048
   for (uint i = index; i < RADIX * gl_NumSubgroups; i += WORKGROUP_SIZE) {
     uint v = localHistogram[i];
     uint sum = subgroupAdd(v);
@@ -152,7 +152,7 @@ void main() {
   }
   barrier();
 
-  // local histogram reduce 128
+  // local histogram reduce 128 or 32
   uint intermediateOffset0 = RADIX * gl_NumSubgroups / gl_SubgroupSize;
   if (index < intermediateOffset0) {
     uint v = localHistogramSum[index];
@@ -165,8 +165,8 @@ void main() {
   }
   barrier();
 
-  // local histogram reduce 4
-  uint intermediateSize1 = RADIX * gl_NumSubgroups / gl_SubgroupSize / gl_SubgroupSize;
+  // local histogram reduce 4 or 1
+  uint intermediateSize1 = max(RADIX * gl_NumSubgroups / gl_SubgroupSize / gl_SubgroupSize, 1);
   if (index < intermediateSize1) {
     uint v = localHistogramSum[intermediateOffset0 + index];
     uint excl = subgroupExclusiveAdd(v);

--- a/src/shader/downsweep.comp
+++ b/src/shader/downsweep.comp
@@ -68,8 +68,8 @@ uint GetBitCount(uvec4 value) {
 }
 
 void main() {
-  uint threadIndex = gl_SubgroupInvocationID;  // 0..31
-  uint subgroupIndex = gl_SubgroupID;  // 0..15
+  uint threadIndex = gl_SubgroupInvocationID;  // 0..31 or 0..63
+  uint subgroupIndex = gl_SubgroupID;  // 0..15 or 0..7
   uint index = subgroupIndex * gl_SubgroupSize + threadIndex;
   uvec4 subgroupMask = GetExclusiveSubgroupMask(threadIndex);
 

--- a/src/shader/downsweep.comp
+++ b/src/shader/downsweep.comp
@@ -54,7 +54,8 @@ shared uint localHistogramSum[RADIX];
 
 // returns 0b00000....11111, where msb is id-1.
 uvec4 GetExclusiveSubgroupMask(uint id) {
-  uint shift = (1 << bitfieldExtract(id, 0, 5)) - 1;  // 1 << (id % 32)
+  // clamp bit-shift right operand between 0..31 to avoid undefined behavior.
+  uint shift = (1 << bitfieldExtract(id, 0, 5)) - 1;  //  (1 << (id % 32)) - 1
   // right shift operation on signed integer copies sign bit, use the trick for masking.
   // (negative)     >> 31 = 111...111
   // (non-negative) >> 31 = 000...000

--- a/src/shader/downsweep.comp
+++ b/src/shader/downsweep.comp
@@ -54,11 +54,16 @@ shared uint localHistogramSum[RADIX];
 
 // returns 0b00000....11111, where msb is id-1.
 uvec4 GetExclusiveSubgroupMask(uint id) {
+  uint shift = (1 << bitfieldExtract(id, 0, 5)) - 1;  // 1 << (id % 32)
+  // right shift operation on signed integer copies sign bit, use the trick for masking.
+  // (negative)     >> 31 = 111...111
+  // (non-negative) >> 31 = 000...000
+  int x = int(id) >> 5;
   return uvec4(
-    (1 << id) - 1,
-    (1 << (id - 32)) - 1,
-    (1 << (id - 64)) - 1,
-    (1 << (id - 96)) - 1
+    (shift & ((-1-x) >> 31)) | ((0-x) >> 31),
+    (shift & (( 0-x) >> 31)) | ((1-x) >> 31),
+    (shift & (( 1-x) >> 31)) | ((2-x) >> 31),
+    (shift & (( 2-x) >> 31)) | ((3-x) >> 31)
   );
 }
 

--- a/src/shader/spine.comp
+++ b/src/shader/spine.comp
@@ -6,7 +6,7 @@
 #extension GL_KHR_shader_subgroup_ballot: enable
 
 const int RADIX = 256;
-#define SUBGROUP_SIZE 32
+#define MAX_SUBGROUP_SIZE 128
 #define WORKGROUP_SIZE 512
 #define PARTITION_DIVISION 8
 const int PARTITION_SIZE = PARTITION_DIVISION * WORKGROUP_SIZE;
@@ -34,11 +34,13 @@ layout (push_constant) uniform PushConstant {
 };
 
 shared uint reduction;
-shared uint intermediate[SUBGROUP_SIZE];
+// we only need array length equal to subgroup size = 32 or 64,
+// but 128 shouldn't affect performance.
+shared uint intermediate[MAX_SUBGROUP_SIZE];
 
 void main() {
-  uint threadIndex = gl_SubgroupInvocationID;  // 0..31
-  uint subgroupIndex = gl_SubgroupID;  // 0..15
+  uint threadIndex = gl_SubgroupInvocationID;  // 0..31 or 0..63
+  uint subgroupIndex = gl_SubgroupID;  // 0..15 or 0..7
   uint index = subgroupIndex * gl_SubgroupSize + threadIndex;
   uint radix = gl_WorkGroupID.x;
 

--- a/src/shader/upsweep.comp
+++ b/src/shader/upsweep.comp
@@ -37,8 +37,8 @@ layout (push_constant) uniform PushConstant {
 shared uint localHistogram[RADIX];
 
 void main() {
-  uint threadIndex = gl_SubgroupInvocationID;  // 0..31
-  uint subgroupIndex = gl_SubgroupID;  // 0..31
+  uint threadIndex = gl_SubgroupInvocationID;  // 0..31 or 0..63
+  uint subgroupIndex = gl_SubgroupID;  // 0..15 or 0..7
   uint index = subgroupIndex * gl_SubgroupSize + threadIndex;
 
   uint elementCount = elementCountReference.elementCount;


### PR DESCRIPTION
- fixed shift operations in `GetExclusiveSubgroupMask()`
- fixed two-stage exclusive prefix sum (`2048 -> 32 -> 1 (was 0) -> 32 -> 2048`) for SubgroupSize=64.
- need tests with devices of SubgroupSize=64.