### PR TITLE
bench: quick single-N runs, per-stage timing, bench_all.py, and README pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /src/generated/
 
 /build/
+/benchmarks/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if(PROJECT_IS_TOP_LEVEL)
   add_executable(bench ${BENCH_SOURCES})
 
   set_target_properties(bench PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
   )

--- a/README.md
+++ b/README.md
@@ -4,46 +4,65 @@ Reduce-then-scan GPU radix sort, implemented as a single-file header-only Vulkan
 
 > **Note:** As of July 2026 (CUDA 13.2, CUB v3.2.0 Onesweep), CUB is faster by 1.50× on keys-only and 1.25× on key-value at N = 2^25. Still a practical choice for Vulkan-based workflows.
 
-
 ## Requirements
 
-- `VulkanSDK >= 1.4.328.1` — download from https://vulkan.lunarg.com/ (push descriptor requires >= 1.4; >= 1.4.328.1 for macOS)
+- `VulkanSDK >= 1.4.328.1` with `pushDescriptor` and `synchronization2` enabled
+    - download from https://vulkan.lunarg.com/ (push descriptor requires >= 1.4; >= 1.4.328.1 for macOS)
 - `cmake >= 3.24`
-- Vulkan 1.3+ device with `pushDescriptor` and `synchronization2` enabled (see [Usage](#usage))
-- Subgroup size of 32 or 64 lanes, and >= 20 KiB of workgroup (`groupshared`) memory — see [Shader Constraints](#shader-constraints)
+- Subgroup size of 32 or 64 lanes, and >= 20 KB of workgroup (`groupshared`) memory
 
-`slangc` v2026.11 is downloaded automatically at configure time. To use the Vulkan SDK's `slangc` instead:
+## Build
 
+`slangc` v2026.11 is downloaded automatically at configure time; to use the Vulkan SDK's instead, add `-DVRDX_SLANGC_FROM_SDK=ON`, e.g. `cmake -B build -DVRDX_SLANGC_FROM_SDK=ON`.
+
+**Linux/macOS**
 ```bash
-cmake -B build -DVRDX_SLANGC_FROM_SDK=ON
+$ cmake -B build -DCMAKE_BUILD_TYPE=Release
+$ cmake --build build -j
 ```
 
-
-## Benchmark
-
-### Build
-
+**Windows**
 ```bash
-$ cmake . -B build                            # slangc downloaded automatically (v2026.11)
-$ cmake . -B build -DVRDX_SLANGC_FROM_SDK=ON  # use slangc from Vulkan SDK instead
+$ cmake -B build
 $ cmake --build build --config Release -j
 ```
 
-### Run
+## Run Benchmark
 
+**Linux/macOS**
 ```bash
-$ ./build/Release/bench.exe <type> [-o output.csv] [--validation] [--no-verify]  # Windows
-$ ./build/bench <type> [-o output.csv] [--validation] [--no-verify]              # Linux
+$ ./build/bench <type> [-n N]... [-o output.csv] [--validation] [--timestamps] [--no-verify]
+```
+
+**Windows**
+```bash
+$ ./build/Release/bench.exe <type> [-n N]... [-o output.csv] [--validation] [--timestamps] [--no-verify]
 ```
 
 - `type`: `cpu`, `vulkan`, `cuda`, `fuchsia`
-- `--validation`: enable Vulkan validation layers (disabled by default to avoid benchmark overhead)
-- `--no-verify`: skip correctness check and proceed directly to benchmarking
-- Sweeps N from 2^18 to 2^25 (128 steps), 1 warmup + 10 timed runs each
-- Outputs median GPU and CPU throughput to CSV
+- `-n N`: run only given N (repeatable); default sweeps 2^18–2^25 (128 steps, 1 warmup + 10 timed runs)
+- `-o output.csv`: write median GPU/CPU throughput to CSV; omit for no CSV
+- `--validation`: enable Vulkan validation layers (off by default)
+- `--timestamps`: per-stage GPU timing (upsweep/spine/downsweep) via Vulkan query pool; adds overhead, Vulkan only
+- `--no-verify`: skip the correctness check
 
-Plot results:
+For example:
 ```bash
+$ ./build/bench vulkan -n 1048576 --validation --timestamps  # debug: validation layers + per-stage timing
+$ ./build/bench vulkan -n 1048576                            # quick throughput check
+```
+
+Run every available backend and plot in one command:
+```bash
+$ python tools/bench_all.py
+```
+Saves each backend's CSV and a `results.png` plot to `benchmarks/<timestamp>/`.
+
+Or save each backend's CSV manually, then plot:
+```bash
+$ ./build/bench vulkan -o vulkan.csv
+$ ./build/bench cuda -o cuda.csv
+$ ./build/bench fuchsia -o fuchsia.csv
 $ python tools/plot.py vulkan.csv cuda.csv fuchsia.csv --output results.png
 ```
 
@@ -58,10 +77,9 @@ Median throughput at N = 2^25. Ratios relative to this library (> 1× means the 
 | 32-bit keys only | 14.93 GItems/s | 15.59 GItems/s (1.04×) | 22.36 GItems/s (1.50×) |
 | 32-bit key-value | 9.35 GItems/s | 5.32 GItems/s (0.57×) | 11.67 GItems/s (1.25×) |
 
-After the downsweep shader rework (splitting the per-wave histogram accumulation from the local offset lookup), keys-only throughput is now within 4% of [Fuchsia radix sort](https://github.com/juliusikkala/fuchsia_radix_sort). Fuchsia remains 1.76× slower on key-value, since it sorts key-value pairs as a single 64-bit key, doubling memory traffic per pass, while this library sorts the two buffers independently. Key-value sort still trails CUB by 1.25× and has room for a similar optimization pass.
+Keys-only is now within 4% of [Fuchsia radix sort](https://github.com/juliusikkala/fuchsia_radix_sort) after the downsweep rework (splitting per-wave histogram accumulation from local offset lookup). Fuchsia is 1.76× slower on key-value — it packs pairs into a single 64-bit key, doubling memory traffic, while this library sorts the two buffers independently. Key-value still trails CUB by 1.25×, with room for a similar optimization.
 
 ![Benchmark Result](media/results.png)
-
 
 ## Integration
 
@@ -69,9 +87,20 @@ Integrate via CMake or by copying `include/vk_radix_sort.h` into your project.
 
 ### CMake
 
-1. Add subdirectory:
+1. Add as a subdirectory:
     ```cmake
     add_subdirectory(path/to/vulkan_radix_sort)
+    ```
+
+    or via `FetchContent`:
+    ```cmake
+    include(FetchContent)
+    FetchContent_Declare(
+      vulkan_radix_sort
+      GIT_REPOSITORY https://github.com/jaesung-cs/vulkan_radix_sort.git
+      GIT_TAG        ...  # pin to a commit
+    )
+    FetchContent_MakeAvailable(vulkan_radix_sort)
     ```
 
 1. Link to `vk_radix_sort`:
@@ -86,7 +115,6 @@ Integrate via CMake or by copying `include/vk_radix_sort.h` into your project.
 ### Copy header
 
 Copy `include/vk_radix_sort.h` into your project and include it directly.
-
 
 ## Usage
 
@@ -106,29 +134,36 @@ Copy `include/vk_radix_sort.h` into your project and include it directly.
 1. Enable the required features when creating the `VkDevice`:
 
     ```c++
-    VkPhysicalDeviceVulkan13Features features13 = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
-    features13.synchronization2 = VK_TRUE;
+    VkPhysicalDeviceVulkan13Features features13 = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
+        .synchronization2 = VK_TRUE,
+    };
 
-    VkPhysicalDeviceVulkan14Features features14 = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES};
-    features14.pNext = &features13;
-    features14.pushDescriptor = VK_TRUE;
+    VkPhysicalDeviceVulkan14Features features14 = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES,
+        .pNext = &features13,
+        .pushDescriptor = VK_TRUE,
+    };
 
-    VkDeviceCreateInfo deviceInfo = {VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
-    deviceInfo.pNext = &features14;
-    // ...
+    VkDeviceCreateInfo deviceInfo = {
+        .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+        .pNext = &features14,
+        ...
+    };
     vkCreateDevice(physicalDevice, &deviceInfo, nullptr, &device);
     ```
 
 1. Create `VkBuffer` for keys and values with `VK_BUFFER_USAGE_STORAGE_BUFFER_BIT`.
 
-1. Create `VrdxSorter`:
+1. Create `VrdxSorter` (`vrdxCreateSorter`):
 
     ```c++
     VrdxSorter sorter = VK_NULL_HANDLE;
-    VrdxSorterCreateInfo sorterInfo = {};
-    sorterInfo.physicalDevice = physicalDevice;
-    sorterInfo.device = device;
-    sorterInfo.pipelineCache = pipelineCache;
+    VrdxSorterCreateInfo sorterInfo = {
+        .physicalDevice = physicalDevice,
+        .device         = device,
+        .pipelineCache  = pipelineCache,  // optional, VK_NULL_HANDLE is valid
+    };
     VkResult result = vrdxCreateSorter(&sorterInfo, &sorter);
     if (result != VK_SUCCESS) { /* handle error */ }
     ```
@@ -140,13 +175,15 @@ Copy `include/vk_radix_sort.h` into your project and include it directly.
     vrdxGetSorterStorageRequirements(sorter, elementCount, VRDX_SORT_MODE_KEYS_ONLY, &requirements);  // keys only
     vrdxGetSorterStorageRequirements(sorter, elementCount, VRDX_SORT_MODE_KEY_VALUE, &requirements);  // key-value
 
-    VkBufferCreateInfo bufferInfo = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-    bufferInfo.size = requirements.size;
-    bufferInfo.usage = requirements.usage;
-    // ...
+    VkBufferCreateInfo bufferInfo = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size  = requirements.size,
+        .usage = requirements.usage,
+        ...
+    };
     ```
 
-1. Record sort commands.
+1. Record sort commands (`vrdxCmdSort`).
 
     Buffer offsets must be multiples of `minStorageBufferOffsetAlignment` (usually `16`).
 
@@ -158,85 +195,60 @@ Copy `include/vk_radix_sort.h` into your project and include it directly.
     - **After** the sort: `COMPUTE_SHADER` stage, `SHADER_WRITE` access.
 
     ```c++
-    VkQueryPool queryPool;  // VK_NULL_HANDLE, or a timestamp query pool with at least 15 entries.
+    // Barrier before the sort
+    VkMemoryBarrier2 memoryBarrier = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2,
+        .srcStageMask  = ...,
+        .srcAccessMask = ...,
+        .dstStageMask  = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,  // | VK_PIPELINE_STAGE_2_TRANSFER_BIT for indirect
+        .dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT,             // | VK_ACCESS_2_TRANSFER_READ_BIT for indirect
+    };
 
-    // Sort keys only
-    VrdxSortInfo info = {};
-    info.elementCount = elementCount;
-    info.keysBuffer      = keysBuffer;
-    info.storageBuffer   = storageBuffer;
-    info.queryPool       = queryPool;
+    VkDependencyInfo dependencyInfo = {
+        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+        .memoryBarrierCount = 1,
+        .pMemoryBarriers    = &memoryBarrier,
+    };
+    vkCmdPipelineBarrier2(commandBuffer, &dependencyInfo);
+
+    // Sort. elementCount is exact for a direct sort, or an upper bound if elementCountBuffer is set
+    // (actual count read from GPU, must not exceed elementCount).
+    VrdxSortInfo info = {
+        .elementCount       = elementCount,
+        .elementCountBuffer = elementCountBuffer,  // omit for a direct sort
+        .keysBuffer         = keysBuffer,
+        .valuesBuffer       = valuesBuffer,        // omit for a keys-only sort
+        .storageBuffer      = storageBuffer,
+        ...  // offsets, queryPool, etc.; set explicitly if needed
+    };
     vrdxCmdSort(commandBuffer, sorter, &info);
 
-    // Sort keys with values (set valuesBuffer)
-    VrdxSortInfo info = {};
-    info.elementCount = elementCount;
-    info.keysBuffer      = keysBuffer;
-    info.valuesBuffer    = valuesBuffer;
-    info.storageBuffer   = storageBuffer;
-    info.queryPool       = queryPool;
-    vrdxCmdSort(commandBuffer, sorter, &info);
-
-    // Sort with indirect element count (read from GPU buffer)
-    // Actual count in elementCountBuffer must not exceed elementCount.
-    VrdxSortInfo info = {};
-    info.elementCount       = maxElementCount;
-    info.elementCountBuffer = elementCountBuffer;
-    info.keysBuffer         = keysBuffer;
-    info.valuesBuffer       = valuesBuffer;
-    info.storageBuffer      = storageBuffer;
-    info.queryPool          = queryPool;
-    vrdxCmdSort(commandBuffer, sorter, &info);
+    // Barrier after the sort
+    memoryBarrier = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2,
+        .srcStageMask  = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+        .srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT,
+        .dstStageMask  = ...,
+        .dstAccessMask = ...,
+    };
+    vkCmdPipelineBarrier2(commandBuffer, &dependencyInfo);
     ```
 
+1. Destroy the `VrdxSorter` (`vrdxDestroySorter`) once no longer needed, e.g. before destroying the `VkDevice`. Ensure the device is idle (no in-flight command buffers referencing the sorter) first; `VK_NULL_HANDLE` is a safe no-op.
+
+    ```c++
+    vrdxDestroySorter(sorter);
+    ```
 
 ## Development Guide
 
-After modifying shaders, run the cmake build. It compiles shaders with `slangc` into `src/generated/*.h`, then assembles `include/vk_radix_sort.h` from `src/vk_radix_sort.h.in`. Each generated file includes the `slangc` version as a comment:
+After modifying shaders or `src/vk_radix_sort.h.in`, run the cmake build — it compiles shaders with `slangc` into `src/generated/*.h`, then assembles `include/vk_radix_sort.h` from the template — and commit the regenerated header. Use the default build (without `-DVRDX_SLANGC_FROM_SDK=ON`) for reproducible output. Each generated file notes its `slangc` version:
 
 ```c
 // Generated by slangc 2026.11
 ```
 
-To bump the `slangc` version, update `SLANG_VERSION` in `cmake/Slangc.cmake` and rebuild.
-
-To bump the library version, update `VERSION` in the `project()` call in `CMakeLists.txt`, rebuild, and commit the regenerated `include/vk_radix_sort.h`.
-
-### Contributing
-
-When modifying shaders or `src/vk_radix_sort.h.in`, commit the regenerated `include/vk_radix_sort.h` as well. Use the default build (without `-DVRDX_SLANGC_FROM_SDK=ON`) to ensure the output is reproducible.
-
-
-## Shader Constraints
-
-### Subgroup size
-
-The downsweep and spine shaders reduce per-wave partial sums (`waveCount = WORKGROUP_SIZE / subgroupSize` values) with a single follow-up `WavePrefixSum`/`WaveActiveSum` call. That call only sees all `waveCount` values at once if they fit in one subgroup, i.e. `waveCount <= subgroupSize`. With `WORKGROUP_SIZE = 512` this requires `subgroupSize >= sqrt(512) ≈ 22.6`, which in practice means **subgroup size 32 or 64** — the two sizes real GPUs actually expose (NVIDIA/Intel use 32, AMD uses 64). Smaller subgroup sizes (e.g. 16, on some mobile/embedded GPUs) leave `waveCount > subgroupSize`, so the reduction silently drops contributions from the waves outside the first subgroup and produces an incorrect sort rather than a validation error.
-
-### Shared memory
-
-The downsweep shader's `groupshared` arrays are sized off `RADIX = 256` and `HISTOGRAM_STRIDE = 17`:
-
-| Array | Elements | Bytes |
-|---|---|---|
-| `sh0` (per-wave histogram) | `HISTOGRAM_STRIDE * RADIX` = 4,352 | 17,408 |
-| `sh1` (radix prefix sums) | `RADIX * 2` = 512 | 2,048 |
-| `sh2` (remaining-count carry) | `RADIX` = 256 | 1,024 |
-| **Total** | 5,120 | **20,480 (20 KiB)** |
-
-Vulkan only mandates `maxComputeSharedMemorySize >= 16384` (16 KiB) as the baseline minimum, so this shader needs more workgroup memory than a spec-minimum implementation guarantees. Desktop and modern mobile GPUs comfortably support well beyond 20 KiB (typically 32–64 KiB or more), but a device sitting at the bare Vulkan floor would fail to create the downsweep pipeline.
-
-
-## TODO
-
-- [ ] Compare with VkRadixSort.
-- [ ] Find optimal `WORKGROUP_SIZE` and `PARTITION_DIVISION` for different devices.
-
-
-## References
-
-- https://github.com/b0nes164/GPUSorting — CUDA kernel references for understanding the algorithm.
-
+Bump `slangc` via `SLANG_VERSION` in `cmake/Slangc.cmake`; bump the library version via `VERSION` in `CMakeLists.txt`'s `project()` call. Rebuild and commit the regenerated header either way.
 
 ## Troubleshooting
 

--- a/bench/bench.cc
+++ b/bench/bench.cc
@@ -118,9 +118,14 @@ Row measure(BenchmarkBase* bench, uint32_t n, const std::string& sort, DataGener
 int main(int argc, char** argv) {
   cxxopts::Options options("bench", "Vulkan radix sort benchmark");
   options.add_options()("type", "Backend type", cxxopts::value<std::string>())(
-      "o,output", "Output CSV file", cxxopts::value<std::string>()->default_value("results.csv"))(
+      "n", "Element count(s) to run instead of the full sweep (repeat -n for multiple)",
+      cxxopts::value<std::vector<uint32_t>>())(
+      "o,output", "Output CSV file; if omitted, no CSV is written", cxxopts::value<std::string>())(
       "validation", "Enable Vulkan validation layers")(
-      "no-verify", "Skip correctness check and proceed to benchmarking")("h,help", "Print usage");
+      "timestamps",
+      "Enable per-stage GPU timing via Vulkan query pool (adds timestamp overhead; Vulkan backend "
+      "only)")("no-verify", "Skip correctness check and proceed to benchmarking")("h,help",
+                                                                                  "Print usage");
   options.parse_positional({"type"});
   options.positional_help("<type>");
   options.custom_help(
@@ -144,13 +149,15 @@ int main(int argc, char** argv) {
   }
 
   std::string type = result["type"].as<std::string>();
-  std::string csv_path = result["output"].as<std::string>();
+  bool has_csv = result.count("output") > 0;
+  std::string csv_path = has_csv ? result["output"].as<std::string>() : "";
   bool validation = result.count("validation") > 0;
+  bool timestamps = result.count("timestamps") > 0;
   bool no_verify = result.count("no-verify") > 0;
 
   std::unique_ptr<BenchmarkBase> bench, cpu;
   try {
-    bench = BenchmarkFactory::Create(type, validation);
+    bench = BenchmarkFactory::Create(type, validation, timestamps);
     cpu = BenchmarkFactory::Create("cpu");
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
@@ -160,11 +167,19 @@ int main(int argc, char** argv) {
   DataGenerator gen;
   std::vector<Row> rows;
 
-  std::mt19937 rng(42);
-  std::uniform_int_distribution<uint32_t> disturb(0, kNDisturbance - 1);
+  std::vector<uint32_t> ns;
+  if (result.count("n")) {
+    ns = result["n"].as<std::vector<uint32_t>>();
+  } else {
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<uint32_t> disturb(0, kNDisturbance - 1);
+    for (int i = 0; i < kNCount; ++i) {
+      ns.push_back(kNMin + static_cast<uint32_t>(i) * kNStep + disturb(rng));
+    }
+  }
 
-  for (int i = 0; i < kNCount; ++i) {
-    uint32_t n = kNMin + static_cast<uint32_t>(i) * kNStep + disturb(rng);
+  for (size_t i = 0; i < ns.size(); ++i) {
+    uint32_t n = ns[i];
 
     if (!no_verify) {
       if (!checkCorrectness(bench.get(), cpu.get(), n, gen)) return 1;
@@ -174,7 +189,7 @@ int main(int argc, char** argv) {
       Row row = measure(bench.get(), n, sort, gen);
       rows.push_back(row);
 
-      std::cout << "[" << std::setw(3) << i + 1 << "/" << kNCount << "]"
+      std::cout << "[" << std::setw(3) << i + 1 << "/" << ns.size() << "]"
                 << " N=" << std::setw(9) << n << " [" << std::setw(4) << sort << "]"
                 << "  gpu: " << std::fixed << std::setprecision(3) << row.gpu_ms << "ms"
                 << " (" << std::setprecision(2) << row.gpu_gitems_s << " GItems/s)"
@@ -193,20 +208,22 @@ int main(int argc, char** argv) {
     }
   }
 
-  std::ofstream csv(csv_path);
-  if (!csv) {
-    std::cerr << "Failed to open " << csv_path << " for writing" << std::endl;
-    return 1;
-  }
+  if (has_csv) {
+    std::ofstream csv(csv_path);
+    if (!csv) {
+      std::cerr << "Failed to open " << csv_path << " for writing" << std::endl;
+      return 1;
+    }
 
-  std::string lib_ver = bench->LibraryVersion();
-  if (!lib_ver.empty()) csv << "# version: " << lib_ver << "\n";
-  csv << "backend,n,sort,gpu_ms,cpu_ms,gpu_gitems_s,cpu_gitems_s\n";
-  for (const auto& r : rows) {
-    csv << type << "," << r.n << "," << r.sort << "," << std::fixed << std::setprecision(6)
-        << r.gpu_ms << "," << r.cpu_ms << "," << r.gpu_gitems_s << "," << r.cpu_gitems_s << "\n";
-  }
+    std::string lib_ver = bench->LibraryVersion();
+    if (!lib_ver.empty()) csv << "# version: " << lib_ver << "\n";
+    csv << "backend,n,sort,gpu_ms,cpu_ms,gpu_gitems_s,cpu_gitems_s\n";
+    for (const auto& r : rows) {
+      csv << type << "," << r.n << "," << r.sort << "," << std::fixed << std::setprecision(6)
+          << r.gpu_ms << "," << r.cpu_ms << "," << r.gpu_gitems_s << "," << r.cpu_gitems_s << "\n";
+    }
 
-  std::cout << "\nResults written to " << csv_path << std::endl;
+    std::cout << "\nResults written to " << csv_path << std::endl;
+  }
   return 0;
 }

--- a/bench/benchmark_factory.cc
+++ b/bench/benchmark_factory.cc
@@ -11,9 +11,10 @@
 
 #include "fuchsia_benchmark.h"
 
-std::unique_ptr<BenchmarkBase> BenchmarkFactory::Create(const std::string& type, bool validation) {
+std::unique_ptr<BenchmarkBase> BenchmarkFactory::Create(const std::string& type, bool validation,
+                                                        bool timestamps) {
   if (type == "cpu") return std::make_unique<CpuBenchmark>();
-  if (type == "vulkan") return std::make_unique<VulkanBenchmark>(validation);
+  if (type == "vulkan") return std::make_unique<VulkanBenchmark>(validation, timestamps);
 
 #ifdef BENCH_CUDA
   if (type == "cuda") return std::make_unique<CudaBenchmark>();

--- a/bench/benchmark_factory.h
+++ b/bench/benchmark_factory.h
@@ -8,7 +8,8 @@ class BenchmarkBase;
 
 class BenchmarkFactory {
  public:
-  static std::unique_ptr<BenchmarkBase> Create(const std::string& type, bool validation = false);
+  static std::unique_ptr<BenchmarkBase> Create(const std::string& type, bool validation = false,
+                                               bool timestamps = false);
 };
 
 #endif  // VK_RADIX_SORT_BENCHMARK_FACTORY_H

--- a/bench/vulkan_benchmark.cc
+++ b/bench/vulkan_benchmark.cc
@@ -48,25 +48,30 @@ std::string VulkanBenchmark::LibraryVersion() const {
          std::to_string(VRDX_VERSION_PATCH);
 }
 
-VulkanBenchmark::VulkanBenchmark(bool validation) {
+VulkanBenchmark::VulkanBenchmark(bool validation, bool timestamps) {
   volkInitialize();
 
   // instance
-  VkApplicationInfo application_info = {VK_STRUCTURE_TYPE_APPLICATION_INFO};
-  application_info.pApplicationName = "vk_radix_sort_benchmark";
-  application_info.applicationVersion = VK_MAKE_API_VERSION(0, 0, 0, 0);
-  application_info.pEngineName = "vk_radix_sort";
-  application_info.engineVersion = VK_MAKE_API_VERSION(0, 0, 0, 0);
-  application_info.apiVersion = VK_API_VERSION_1_4;
+  VkApplicationInfo application_info = {
+      .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+      .pApplicationName = "vk_radix_sort_benchmark",
+      .applicationVersion =
+          VK_MAKE_API_VERSION(VRDX_VERSION_MAJOR, VRDX_VERSION_MINOR, VRDX_VERSION_PATCH, 0),
+      .pEngineName = "vk_radix_sort",
+      .engineVersion =
+          VK_MAKE_API_VERSION(VRDX_VERSION_MAJOR, VRDX_VERSION_MINOR, VRDX_VERSION_PATCH, 0),
+      .apiVersion = VK_API_VERSION_1_4,
+  };
 
   VkDebugUtilsMessengerCreateInfoEXT messenger_info = {
-      VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT};
-  messenger_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT |
-                                   VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
-                                   VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-  messenger_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
-  messenger_info.pfnUserCallback = DebugCallback;
+      .sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
+      .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT |
+                         VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+                         VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT,
+      .messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+                     VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT,
+      .pfnUserCallback = DebugCallback,
+  };
 
   std::vector<const char*> layers;
   std::vector<const char*> instance_extensions = {
@@ -80,16 +85,18 @@ VulkanBenchmark::VulkanBenchmark(bool validation) {
     instance_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
   }
 
-  VkInstanceCreateInfo instance_info = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+  VkInstanceCreateInfo instance_info = {
+      .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+      .pNext = validation ? &messenger_info : nullptr,
 #ifdef __APPLE__
-  instance_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+      .flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR,
 #endif
-  instance_info.pNext = validation ? &messenger_info : nullptr;
-  instance_info.pApplicationInfo = &application_info;
-  instance_info.enabledLayerCount = static_cast<uint32_t>(layers.size());
-  instance_info.ppEnabledLayerNames = layers.data();
-  instance_info.enabledExtensionCount = static_cast<uint32_t>(instance_extensions.size());
-  instance_info.ppEnabledExtensionNames = instance_extensions.data();
+      .pApplicationInfo = &application_info,
+      .enabledLayerCount = static_cast<uint32_t>(layers.size()),
+      .ppEnabledLayerNames = layers.data(),
+      .enabledExtensionCount = static_cast<uint32_t>(instance_extensions.size()),
+      .ppEnabledExtensionNames = instance_extensions.data(),
+  };
   vkCreateInstance(&instance_info, NULL, &instance_);
   volkLoadInstance(instance_);
 
@@ -129,10 +136,12 @@ VulkanBenchmark::VulkanBenchmark(bool validation) {
       1.f,
   };
   std::vector<VkDeviceQueueCreateInfo> queue_infos(1);
-  queue_infos[0] = {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
-  queue_infos[0].queueFamilyIndex = queue_family_index_;
-  queue_infos[0].queueCount = queue_priorities.size();
-  queue_infos[0].pQueuePriorities = queue_priorities.data();
+  queue_infos[0] = {
+      .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+      .queueFamilyIndex = queue_family_index_,
+      .queueCount = static_cast<uint32_t>(queue_priorities.size()),
+      .pQueuePriorities = queue_priorities.data(),
+  };
 
   std::vector<const char*> device_extensions = {
 #ifdef __APPLE__
@@ -141,66 +150,80 @@ VulkanBenchmark::VulkanBenchmark(bool validation) {
   };
 
   VkPhysicalDeviceVulkan13Features features13 = {
-      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
-  features13.synchronization2 = VK_TRUE;
+      .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
+      .synchronization2 = VK_TRUE,
+  };
 
   VkPhysicalDeviceVulkan14Features features14 = {
-      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES};
-  features14.pNext = &features13;
-  features14.pushDescriptor = VK_TRUE;
+      .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES,
+      .pNext = &features13,
+      .pushDescriptor = VK_TRUE,
+  };
 
-  VkDeviceCreateInfo device_info = {VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
-  device_info.pNext = &features14;
-  device_info.queueCreateInfoCount = queue_infos.size();
-  device_info.pQueueCreateInfos = queue_infos.data();
-  device_info.enabledExtensionCount = device_extensions.size();
-  device_info.ppEnabledExtensionNames = device_extensions.data();
+  VkDeviceCreateInfo device_info = {
+      .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+      .pNext = &features14,
+      .queueCreateInfoCount = static_cast<uint32_t>(queue_infos.size()),
+      .pQueueCreateInfos = queue_infos.data(),
+      .enabledExtensionCount = static_cast<uint32_t>(device_extensions.size()),
+      .ppEnabledExtensionNames = device_extensions.data(),
+  };
   vkCreateDevice(physical_device_, &device_info, NULL, &device_);
   volkLoadDevice(device_);
 
   vkGetDeviceQueue(device_, queue_family_index_, 0, &queue_);
 
   // vma
-  VmaVulkanFunctions functions = {};
-  functions.vkGetInstanceProcAddr = vkGetInstanceProcAddr;
-  functions.vkGetDeviceProcAddr = vkGetDeviceProcAddr;
+  VmaVulkanFunctions functions = {
+      .vkGetInstanceProcAddr = vkGetInstanceProcAddr,
+      .vkGetDeviceProcAddr = vkGetDeviceProcAddr,
+  };
 
-  VmaAllocatorCreateInfo allocator_info = {};
-  allocator_info.physicalDevice = physical_device_;
-  allocator_info.device = device_;
-  allocator_info.instance = instance_;
-  allocator_info.pVulkanFunctions = &functions;
-  allocator_info.vulkanApiVersion = application_info.apiVersion;
+  VmaAllocatorCreateInfo allocator_info = {
+      .physicalDevice = physical_device_,
+      .device = device_,
+      .pVulkanFunctions = &functions,
+      .instance = instance_,
+      .vulkanApiVersion = application_info.apiVersion,
+  };
   vmaCreateAllocator(&allocator_info, &allocator_);
 
   // commands
-  VkCommandPoolCreateInfo command_pool_info = {VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
-  command_pool_info.flags =
-      VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
-  command_pool_info.queueFamilyIndex = queue_family_index_;
+  VkCommandPoolCreateInfo command_pool_info = {
+      .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+      .flags =
+          VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
+      .queueFamilyIndex = queue_family_index_,
+  };
   vkCreateCommandPool(device_, &command_pool_info, NULL, &command_pool_);
 
   VkCommandBufferAllocateInfo command_buffer_info = {
-      VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
-  command_buffer_info.commandPool = command_pool_;
-  command_buffer_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-  command_buffer_info.commandBufferCount = 1;
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+      .commandPool = command_pool_,
+      .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+      .commandBufferCount = 1,
+  };
   vkAllocateCommandBuffers(device_, &command_buffer_info, &command_buffer_);
 
   // fence
-  VkFenceCreateInfo fence_info = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+  VkFenceCreateInfo fence_info = {.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
   vkCreateFence(device_, &fence_info, NULL, &fence_);
 
-  // timestamp query pool
-  VkQueryPoolCreateInfo query_pool_info = {VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
-  query_pool_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
-  query_pool_info.queryCount = timestamp_count;
-  vkCreateQueryPool(device_, &query_pool_info, NULL, &query_pool_);
+  // timestamp query pool (optional; adds vkCmdWriteTimestamp overhead to each sort)
+  if (timestamps) {
+    VkQueryPoolCreateInfo query_pool_info = {
+        .sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO,
+        .queryType = VK_QUERY_TYPE_TIMESTAMP,
+        .queryCount = timestamp_count,
+    };
+    vkCreateQueryPool(device_, &query_pool_info, NULL, &query_pool_);
+  }
 
   // sorter
-  VrdxSorterCreateInfo sorter_info = {};
-  sorter_info.physicalDevice = physical_device_;
-  sorter_info.device = device_;
+  VrdxSorterCreateInfo sorter_info = {
+      .physicalDevice = physical_device_,
+      .device = device_,
+  };
   vrdxCreateSorter(&sorter_info, &sorter_);
 }
 
@@ -234,15 +257,18 @@ void VulkanBenchmark::Reallocate(Buffer* buffer, VkDeviceSize size, VkBufferUsag
 
   if (buffer->allocation) vmaDestroyBuffer(allocator_, buffer->buffer, buffer->allocation);
 
-  VkBufferCreateInfo buffer_info = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-  buffer_info.size = size;
-  buffer_info.usage = usage;
-  VmaAllocationCreateInfo allocation_create_info = {};
+  VkBufferCreateInfo buffer_info = {
+      .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+      .size = size,
+      .usage = usage,
+  };
+  VmaAllocationCreateInfo allocation_create_info = {
+      .usage = VMA_MEMORY_USAGE_AUTO,
+  };
   if (mapped) {
     allocation_create_info.flags =
         VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
   }
-  allocation_create_info.usage = VMA_MEMORY_USAGE_AUTO;
 
   VmaAllocationInfo allocation_info;
   vmaCreateBuffer(allocator_, &buffer_info, &allocation_create_info, &buffer->buffer,
@@ -270,24 +296,28 @@ VulkanBenchmark::Results VulkanBenchmark::Sort(const std::vector<uint32_t>& keys
   std::memcpy(staging_.map, keys.data(), element_count * sizeof(uint32_t));
 
   VkCommandBufferBeginInfo command_buffer_begin_info = {
-      VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
-  command_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+      .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+  };
   vkBeginCommandBuffer(command_buffer_, &command_buffer_begin_info);
 
-  vkCmdResetQueryPool(command_buffer_, query_pool_, 0, timestamp_count);
+  if (query_pool_) vkCmdResetQueryPool(command_buffer_, query_pool_, 0, timestamp_count);
 
   // copy to keys buffer
-  VkBufferCopy region = {};
-  region.srcOffset = 0;
-  region.dstOffset = 0;
-  region.size = element_count * sizeof(uint32_t);
+  VkBufferCopy region = {
+      .srcOffset = 0,
+      .dstOffset = 0,
+      .size = element_count * sizeof(uint32_t),
+  };
   vkCmdCopyBuffer(command_buffer_, staging_.buffer, keys_.buffer, 1, &region);
 
   vkEndCommandBuffer(command_buffer_);
 
-  VkSubmitInfo submit = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
-  submit.commandBufferCount = 1;
-  submit.pCommandBuffers = &command_buffer_;
+  VkSubmitInfo submit = {
+      .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+      .commandBufferCount = 1,
+      .pCommandBuffers = &command_buffer_,
+  };
   vkQueueSubmit(queue_, 1, &submit, fence_);
   vkWaitForFences(device_, 1, &fence_, VK_TRUE, UINT64_MAX);
   vkResetFences(device_, 1, &fence_);
@@ -295,11 +325,12 @@ VulkanBenchmark::Results VulkanBenchmark::Sort(const std::vector<uint32_t>& keys
   // sort
   vkBeginCommandBuffer(command_buffer_, &command_buffer_begin_info);
 
-  VrdxSortInfo sort_info = {};
-  sort_info.elementCount = element_count;
-  sort_info.keysBuffer = keys_.buffer;
-  sort_info.storageBuffer = storage_.buffer;
-  sort_info.queryPool = query_pool_;
+  VrdxSortInfo sort_info = {
+      .elementCount = element_count,
+      .keysBuffer = keys_.buffer,
+      .storageBuffer = storage_.buffer,
+      .queryPool = query_pool_,
+  };
   vrdxCmdSort(command_buffer_, sorter_, &sort_info);
 
   vkEndCommandBuffer(command_buffer_);
@@ -312,9 +343,11 @@ VulkanBenchmark::Results VulkanBenchmark::Sort(const std::vector<uint32_t>& keys
   // copy back
   vkBeginCommandBuffer(command_buffer_, &command_buffer_begin_info);
 
-  region.srcOffset = 0;
-  region.dstOffset = 0;
-  region.size = element_count * sizeof(uint32_t);
+  region = {
+      .srcOffset = 0,
+      .dstOffset = 0,
+      .size = element_count * sizeof(uint32_t),
+  };
   vkCmdCopyBuffer(command_buffer_, keys_.buffer, staging_.buffer, 1, &region);
 
   vkEndCommandBuffer(command_buffer_);
@@ -322,25 +355,30 @@ VulkanBenchmark::Results VulkanBenchmark::Sort(const std::vector<uint32_t>& keys
   vkWaitForFences(device_, 1, &fence_, VK_TRUE, UINT64_MAX);
   vkResetFences(device_, 1, &fence_);
 
-  std::vector<uint64_t> timestamps(timestamp_count);
-  vkGetQueryPoolResults(device_, query_pool_, 0, timestamps.size(),
-                        timestamps.size() * sizeof(uint64_t), timestamps.data(), sizeof(uint64_t),
-                        VK_QUERY_RESULT_64_BIT);
-
-  auto ticks_to_ns = [&](uint64_t ticks) -> uint64_t {
-    return static_cast<uint64_t>(ticks * timestamp_period_);
-  };
-
   Results result;
   result.keys.resize(element_count);
   std::memcpy(result.keys.data(), staging_.map, element_count * sizeof(uint32_t));
-  result.total_time = ticks_to_ns(timestamps[timestamp_count - 1] - timestamps[0]);
   result.cpu_time =
       std::chrono::duration_cast<std::chrono::nanoseconds>(cpu_end - cpu_start).count();
-  for (int pass = 0; pass < 4; ++pass) {
-    result.upsweep_ns += ticks_to_ns(timestamps[2 + 3 * pass] - timestamps[1 + 3 * pass]);
-    result.spine_ns += ticks_to_ns(timestamps[3 + 3 * pass] - timestamps[2 + 3 * pass]);
-    result.downsweep_ns += ticks_to_ns(timestamps[4 + 3 * pass] - timestamps[3 + 3 * pass]);
+
+  if (query_pool_) {
+    std::vector<uint64_t> timestamps(timestamp_count);
+    vkGetQueryPoolResults(device_, query_pool_, 0, timestamps.size(),
+                          timestamps.size() * sizeof(uint64_t), timestamps.data(), sizeof(uint64_t),
+                          VK_QUERY_RESULT_64_BIT);
+
+    auto ticks_to_ns = [&](uint64_t ticks) -> uint64_t {
+      return static_cast<uint64_t>(ticks * timestamp_period_);
+    };
+
+    result.total_time = ticks_to_ns(timestamps[timestamp_count - 1] - timestamps[0]);
+    for (int pass = 0; pass < 4; ++pass) {
+      result.upsweep_ns += ticks_to_ns(timestamps[2 + 3 * pass] - timestamps[1 + 3 * pass]);
+      result.spine_ns += ticks_to_ns(timestamps[3 + 3 * pass] - timestamps[2 + 3 * pass]);
+      result.downsweep_ns += ticks_to_ns(timestamps[4 + 3 * pass] - timestamps[3 + 3 * pass]);
+    }
+  } else {
+    result.total_time = result.cpu_time;
   }
   return result;
 }
@@ -371,37 +409,43 @@ VulkanBenchmark::Results VulkanBenchmark::SortKeyValue(const std::vector<uint32_
   std::memcpy(staging_.map + 2 * inout_size, &element_count, sizeof(uint32_t));
 
   VkCommandBufferBeginInfo command_buffer_begin_info = {
-      VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
-  command_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+      .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+  };
   vkBeginCommandBuffer(command_buffer_, &command_buffer_begin_info);
 
-  vkCmdResetQueryPool(command_buffer_, query_pool_, 0, timestamp_count);
+  if (query_pool_) vkCmdResetQueryPool(command_buffer_, query_pool_, 0, timestamp_count);
 
   // copy to keys/values/element count buffers
-  VkBufferCopy keys_region = {};
-  keys_region.srcOffset = 0;
-  keys_region.dstOffset = 0;
-  keys_region.size = inout_size;
+  VkBufferCopy keys_region = {
+      .srcOffset = 0,
+      .dstOffset = 0,
+      .size = inout_size,
+  };
   vkCmdCopyBuffer(command_buffer_, staging_.buffer, keys_.buffer, 1, &keys_region);
 
-  VkBufferCopy values_region = {};
-  values_region.srcOffset = inout_size;
-  values_region.dstOffset = 0;
-  values_region.size = inout_size;
+  VkBufferCopy values_region = {
+      .srcOffset = inout_size,
+      .dstOffset = 0,
+      .size = inout_size,
+  };
   vkCmdCopyBuffer(command_buffer_, staging_.buffer, values_.buffer, 1, &values_region);
 
-  VkBufferCopy element_count_region = {};
-  element_count_region.srcOffset = 2 * inout_size;
-  element_count_region.dstOffset = 0;
-  element_count_region.size = sizeof(uint32_t);
+  VkBufferCopy element_count_region = {
+      .srcOffset = 2 * inout_size,
+      .dstOffset = 0,
+      .size = sizeof(uint32_t),
+  };
   vkCmdCopyBuffer(command_buffer_, staging_.buffer, element_count_.buffer, 1,
                   &element_count_region);
 
   vkEndCommandBuffer(command_buffer_);
 
-  VkSubmitInfo submit = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
-  submit.commandBufferCount = 1;
-  submit.pCommandBuffers = &command_buffer_;
+  VkSubmitInfo submit = {
+      .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+      .commandBufferCount = 1,
+      .pCommandBuffers = &command_buffer_,
+  };
   vkQueueSubmit(queue_, 1, &submit, fence_);
   vkWaitForFences(device_, 1, &fence_, VK_TRUE, UINT64_MAX);
   vkResetFences(device_, 1, &fence_);
@@ -409,13 +453,14 @@ VulkanBenchmark::Results VulkanBenchmark::SortKeyValue(const std::vector<uint32_
   // sort
   vkBeginCommandBuffer(command_buffer_, &command_buffer_begin_info);
 
-  VrdxSortInfo sort_info = {};
-  sort_info.elementCount = element_count;
-  sort_info.elementCountBuffer = element_count_.buffer;
-  sort_info.keysBuffer = keys_.buffer;
-  sort_info.valuesBuffer = values_.buffer;
-  sort_info.storageBuffer = storage_.buffer;
-  sort_info.queryPool = query_pool_;
+  VrdxSortInfo sort_info = {
+      .elementCount = element_count,
+      .elementCountBuffer = element_count_.buffer,
+      .keysBuffer = keys_.buffer,
+      .valuesBuffer = values_.buffer,
+      .storageBuffer = storage_.buffer,
+      .queryPool = query_pool_,
+  };
   vrdxCmdSort(command_buffer_, sorter_, &sort_info);
 
   vkEndCommandBuffer(command_buffer_);
@@ -428,16 +473,18 @@ VulkanBenchmark::Results VulkanBenchmark::SortKeyValue(const std::vector<uint32_
   // copy back
   vkBeginCommandBuffer(command_buffer_, &command_buffer_begin_info);
 
-  VkBufferCopy keys_back_region = {};
-  keys_back_region.srcOffset = 0;
-  keys_back_region.dstOffset = 0;
-  keys_back_region.size = inout_size;
+  VkBufferCopy keys_back_region = {
+      .srcOffset = 0,
+      .dstOffset = 0,
+      .size = inout_size,
+  };
   vkCmdCopyBuffer(command_buffer_, keys_.buffer, staging_.buffer, 1, &keys_back_region);
 
-  VkBufferCopy values_back_region = {};
-  values_back_region.srcOffset = 0;
-  values_back_region.dstOffset = inout_size;
-  values_back_region.size = inout_size;
+  VkBufferCopy values_back_region = {
+      .srcOffset = 0,
+      .dstOffset = inout_size,
+      .size = inout_size,
+  };
   vkCmdCopyBuffer(command_buffer_, values_.buffer, staging_.buffer, 1, &values_back_region);
 
   vkEndCommandBuffer(command_buffer_);
@@ -445,27 +492,32 @@ VulkanBenchmark::Results VulkanBenchmark::SortKeyValue(const std::vector<uint32_
   vkWaitForFences(device_, 1, &fence_, VK_TRUE, UINT64_MAX);
   vkResetFences(device_, 1, &fence_);
 
-  std::vector<uint64_t> timestamps(timestamp_count);
-  vkGetQueryPoolResults(device_, query_pool_, 0, timestamps.size(),
-                        timestamps.size() * sizeof(uint64_t), timestamps.data(), sizeof(uint64_t),
-                        VK_QUERY_RESULT_64_BIT);
-
-  auto ticks_to_ns = [&](uint64_t ticks) -> uint64_t {
-    return static_cast<uint64_t>(ticks * timestamp_period_);
-  };
-
   Results result;
   result.keys.resize(element_count);
   result.values.resize(element_count);
   std::memcpy(result.keys.data(), staging_.map, element_count * sizeof(uint32_t));
   std::memcpy(result.values.data(), staging_.map + inout_size, element_count * sizeof(uint32_t));
-  result.total_time = ticks_to_ns(timestamps[timestamp_count - 1] - timestamps[0]);
   result.cpu_time =
       std::chrono::duration_cast<std::chrono::nanoseconds>(cpu_end - cpu_start).count();
-  for (int pass = 0; pass < 4; ++pass) {
-    result.upsweep_ns += ticks_to_ns(timestamps[2 + 3 * pass] - timestamps[1 + 3 * pass]);
-    result.spine_ns += ticks_to_ns(timestamps[3 + 3 * pass] - timestamps[2 + 3 * pass]);
-    result.downsweep_ns += ticks_to_ns(timestamps[4 + 3 * pass] - timestamps[3 + 3 * pass]);
+
+  if (query_pool_) {
+    std::vector<uint64_t> timestamps(timestamp_count);
+    vkGetQueryPoolResults(device_, query_pool_, 0, timestamps.size(),
+                          timestamps.size() * sizeof(uint64_t), timestamps.data(), sizeof(uint64_t),
+                          VK_QUERY_RESULT_64_BIT);
+
+    auto ticks_to_ns = [&](uint64_t ticks) -> uint64_t {
+      return static_cast<uint64_t>(ticks * timestamp_period_);
+    };
+
+    result.total_time = ticks_to_ns(timestamps[timestamp_count - 1] - timestamps[0]);
+    for (int pass = 0; pass < 4; ++pass) {
+      result.upsweep_ns += ticks_to_ns(timestamps[2 + 3 * pass] - timestamps[1 + 3 * pass]);
+      result.spine_ns += ticks_to_ns(timestamps[3 + 3 * pass] - timestamps[2 + 3 * pass]);
+      result.downsweep_ns += ticks_to_ns(timestamps[4 + 3 * pass] - timestamps[3 + 3 * pass]);
+    }
+  } else {
+    result.total_time = result.cpu_time;
   }
   return result;
 }

--- a/bench/vulkan_benchmark.h
+++ b/bench/vulkan_benchmark.h
@@ -18,7 +18,7 @@ class VulkanBenchmark : public BenchmarkBase {
   };
 
  public:
-  explicit VulkanBenchmark(bool validation = false);
+  explicit VulkanBenchmark(bool validation = false, bool timestamps = false);
   ~VulkanBenchmark() override;
 
   std::string LibraryVersion() const override;

--- a/tools/bench_all.py
+++ b/tools/bench_all.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Run all available benchmark backends, collect CSVs, and generate a plot.
+
+Usage:
+    python tools/bench_all.py [options]
+    python tools/bench_all.py --build-dir build/Release --no-verify
+"""
+
+import argparse
+import datetime
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BACKENDS = ["vulkan", "fuchsia", "cuda"]
+
+
+def find_bench(build_dir: Path) -> Path:
+    for candidate in [
+        build_dir / "bench",
+        build_dir / "bench.exe",
+        build_dir / "Release" / "bench",
+        build_dir / "Release" / "bench.exe",
+    ]:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        f"bench executable not found under {build_dir}. Run cmake --build first."
+    )
+
+
+def run_backend(bench: Path, backend: str, csv: Path, extra: list[str]) -> bool:
+    cmd = [str(bench), backend, "-o", str(csv)] + extra
+    print(f"\n=== {backend} ===")
+    print("$", " ".join(cmd))
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"[{backend}] exited {result.returncode} — skipping.")
+        return False
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run benchmark backends, save CSVs, and plot."
+    )
+    parser.add_argument(
+        "--build-dir",
+        default="build",
+        metavar="DIR",
+        help="CMake build directory (default: build)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        metavar="DIR",
+        help="Output directory (default: benchmarks/<timestamp>)",
+    )
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        default=DEFAULT_BACKENDS,
+        metavar="BACKEND",
+        help=f"Backends to run (default: {' '.join(DEFAULT_BACKENDS)})",
+    )
+    parser.add_argument("--no-plot", action="store_true", help="Skip plot step")
+    parser.add_argument(
+        "--no-verify", action="store_true", help="Pass --no-verify to bench"
+    )
+    parser.add_argument(
+        "--validation", action="store_true", help="Pass --validation to bench"
+    )
+    args = parser.parse_args()
+
+    build_dir = Path(args.build_dir)
+    if not build_dir.is_absolute():
+        build_dir = REPO_ROOT / build_dir
+
+    bench = find_bench(build_dir)
+    print(f"bench: {bench}")
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else REPO_ROOT / "benchmarks" / timestamp
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"output: {out_dir}")
+
+    extra = []
+    if args.no_verify:
+        extra.append("--no-verify")
+    if args.validation:
+        extra.append("--validation")
+
+    csvs = []
+    for backend in args.backends:
+        csv = out_dir / f"{backend}.csv"
+        if run_backend(bench, backend, csv, extra):
+            csvs.append(csv)
+
+    if not csvs:
+        print("\nAll backends failed.")
+        sys.exit(1)
+
+    if not args.no_plot:
+        plot_out = out_dir / "results.png"
+        cmd = (
+            [sys.executable, str(REPO_ROOT / "tools" / "plot.py")]
+            + [str(c) for c in csvs]
+            + ["--output", str(plot_out)]
+        )
+        print(f"\n=== plot ===")
+        print("$", " ".join(cmd))
+        subprocess.run(cmd, check=True)
+
+    print(f"\nResults in {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bench_all.py
+++ b/tools/bench_all.py
@@ -8,8 +8,10 @@ Usage:
 
 import argparse
 import datetime
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -86,8 +88,6 @@ def main():
         if args.output_dir
         else REPO_ROOT / "benchmarks" / timestamp
     )
-    out_dir.mkdir(parents=True, exist_ok=True)
-    print(f"output: {out_dir}")
 
     extra = []
     if args.no_verify:
@@ -95,26 +95,35 @@ def main():
     if args.validation:
         extra.append("--validation")
 
-    csvs = []
-    for backend in args.backends:
-        csv = out_dir / f"{backend}.csv"
-        if run_backend(bench, backend, csv, extra):
-            csvs.append(csv)
+    # Write to a scratch directory first so out_dir is only created once we
+    # actually have result files to put in it (not left behind empty if
+    # every backend fails).
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        csvs = []
+        for backend in args.backends:
+            csv = tmp_dir / f"{backend}.csv"
+            if run_backend(bench, backend, csv, extra):
+                csvs.append(csv)
 
-    if not csvs:
-        print("\nAll backends failed.")
-        sys.exit(1)
+        if not csvs:
+            print("\nAll backends failed.")
+            sys.exit(1)
 
-    if not args.no_plot:
-        plot_out = out_dir / "results.png"
-        cmd = (
-            [sys.executable, str(REPO_ROOT / "tools" / "plot.py")]
-            + [str(c) for c in csvs]
-            + ["--output", str(plot_out)]
-        )
-        print(f"\n=== plot ===")
-        print("$", " ".join(cmd))
-        subprocess.run(cmd, check=True)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        print(f"output: {out_dir}")
+        csvs = [shutil.move(str(csv), out_dir / csv.name) for csv in csvs]
+
+        if not args.no_plot:
+            plot_out = out_dir / "results.png"
+            cmd = (
+                [sys.executable, str(REPO_ROOT / "tools" / "plot.py")]
+                + [str(c) for c in csvs]
+                + ["--output", str(plot_out)]
+            )
+            print(f"\n=== plot ===")
+            print("$", " ".join(cmd))
+            subprocess.run(cmd, check=True)
 
     print(f"\nResults in {out_dir}")
 

--- a/tools/plot.py
+++ b/tools/plot.py
@@ -32,8 +32,11 @@ def load(paths):
         file_backends = set()
         with open(path, newline="") as f:
             reader = csv.DictReader(
-                (line for line in f
-                 if not line.startswith("#") or _parse_meta(line, file_meta)),
+                (
+                    line
+                    for line in f
+                    if not line.startswith("#") or _parse_meta(line, file_meta)
+                ),
             )
             for row in reader:
                 backend = row["backend"]
@@ -73,8 +76,7 @@ def main():
     ns = sorted({n for sorts in data.values() for series in sorts.values() for n in series})
 
     colors = ["tab:blue", "tab:orange", "tab:green", "tab:red"]
-    backend_color = {b: colors[i % len(colors)]
-                     for i, b in enumerate(backends)}
+    backend_color = {b: colors[i % len(colors)] for i, b in enumerate(backends)}
 
     fig, (ax_keys, ax_kv) = plt.subplots(2, 1, figsize=(10, 10), sharex=True)
 
@@ -96,8 +98,13 @@ def main():
             backend_ns = sorted(data[backend][sort].keys())
             for timing, ls in [("gpu", "-"), ("cpu", "--")]:
                 ys = [data[backend][sort][n][timing] for n in backend_ns]
-                ax.plot(backend_ns, ys, color=color, linestyle=ls,
-                        label=f"{backend} {timing.upper()}")
+                ax.plot(
+                    backend_ns,
+                    ys,
+                    color=color,
+                    linestyle=ls,
+                    label=f"{backend} {timing.upper()}",
+                )
         ax.set_ylabel("Throughput (GItems/s)")
         ax.set_title(title)
         ax.xaxis.set_major_formatter(
@@ -111,9 +118,16 @@ def main():
             target = 1 << k
             nearest = min(ns, key=lambda n: abs(n - target))
             if abs(nearest - target) <= target * 0.02:
-                ax.text(nearest, 0.01, f"$2^{{{k}}}$",
-                        transform=ax.get_xaxis_transform(),
-                        ha="center", va="bottom", fontsize=8, color="gray")
+                ax.text(
+                    nearest,
+                    0.01,
+                    f"$2^{{{k}}}$",
+                    transform=ax.get_xaxis_transform(),
+                    ha="center",
+                    va="bottom",
+                    fontsize=8,
+                    color="gray",
+                )
         ax.xaxis.set_major_locator(ticker.FixedLocator(ns[3::4]))
         ax.set_xticks(ns, minor=True)
         ax.yaxis.set_major_locator(ticker.AutoLocator())
@@ -123,7 +137,7 @@ def main():
         ax.grid(True, which="minor", linestyle=":", alpha=0.2)
 
     plot_panel(ax_keys, "keys", "Keys-Only Sort")
-    plot_panel(ax_kv,   "kv",   "Key-Value Sort")
+    plot_panel(ax_kv, "kv", "Key-Value Sort")
 
     ax_kv.set_xlabel("N (elements)")
     plt.setp(ax_kv.get_xticklabels(), rotation=90)


### PR DESCRIPTION
## Summary

Benchmark tooling improvements and a README pass to document them.

- `bench`: `-n` now accepts one or more element counts to run instead of the full 2^18–2^25 sweep; `-o`/`--output` no longer has a default, so omitting it skips CSV output.
- `bench`: add `--timestamps`, which opts into a Vulkan query pool for per-stage (upsweep/spine/downsweep) GPU timing. Off by default to avoid timestamp overhead on every sort.
- Add `tools/bench_all.py` to run all available backends (vulkan, fuchsia, cuda — skipped if unavailable) and plot in one command; saves CSVs and `results.png` to `benchmarks/<timestamp>/`, and only creates that directory once there are results to put in it (avoids empty dirs when every backend fails).
- README: move Build out from under Benchmark (it produces the header-only library, not just the bench binary), document the new `-n`/`--timestamps`/`bench_all.py` options, add a FetchContent integration option, document `vrdxDestroySorter`, and tighten wording throughout.
- `CMakeLists.txt`: bump the bench target to C++20 for designated initializers used in the README's Vulkan struct examples and in `vulkan_benchmark.cc`.
- Reformat `tools/plot.py` with black (no behavior change).

## Test plan

- [x] `python tools/bench_all.py` runs end-to-end on at least one backend and produces `results.png`
- [x] `./build/bench vulkan -n 1048576 --timestamps` prints per-stage timing without error
- [x] `./build/bench vulkan` (no `-o`) completes without writing a CSV
- [x] Confirm the bench target still builds after the C++20 bump
